### PR TITLE
Fix csp config 

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,5 +9,5 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self' 'unsafe-inline' *.gny.io;"
+    Content-Security-Policy = "default-src 'self' 'unsafe-inline' 'unsafe-eval' *.gny.io;"
     

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,4 +9,4 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src *.gny.io;"
+    Content-Security-Policy = "default-src 'self' *.gny.io;"

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,5 +9,5 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src *.gny.io; script-src 'self'; img-src 'self';"
+    Content-Security-Policy = "default-src 'self' *.gny.io;"
     

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,5 +9,5 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src *.gny.io; img-src 'self';"
+    Content-Security-Policy = "default-src *.gny.io; script-src 'self'; img-src 'self';"
     

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,7 @@
   # functions build directory
   functions = "functions-build"
   framework = "#custom"
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "default-src *.gny.io;"

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,4 +9,5 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self' *.gny.io;"
+    Content-Security-Policy = "default-src *.gny.io; img-src 'self';"
+    

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,5 +9,5 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self' *.gny.io;"
+    Content-Security-Policy = "default-src 'self' 'unsafe-inline' *.gny.io;"
     


### PR DESCRIPTION
@a1300  It should be mentioned that 

1. In order to pass the csp checking to get all the resources so that the site works, I have to add two unsafe items: `unsafe-inline`and `unsafe-eval`. 
2. I tried to use nuxt.config.js to add csp policies, but it is not compatible for SPA mode. It only support SSR mode which cannot be used for netlify application. 

So the contradiction appears. 